### PR TITLE
Mark properties required based on Optionals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ lazy val deps  = Seq(
   "javax.validation" % "validation-api" % "2.0.1.Final",
   "org.slf4j" % "slf4j-api" % slf4jVersion,
   "io.github.classgraph" % "classgraph" % "4.8.22",
+  "com.google.guava" % "guava" % "25.0-jre", 
   "org.scalatest" %% "scalatest" % "3.0.7" % "test",
   "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
   "com.github.java-json-tools" % "json-schema-validator" % "2.2.10" % "test",

--- a/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaProperty.java
+++ b/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaProperty.java
@@ -1,0 +1,19 @@
+package com.kjetland.jackson.jsonSchema.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({METHOD, FIELD, TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonSchemaProperty {
+  /**
+   * This dictates whether or not to mark a property of a schema model as required or not.
+   * This overrides ALL other behavior affecting required.
+   */
+  boolean required();
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/ManyPrimitives.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/ManyPrimitives.java
@@ -2,8 +2,12 @@ package com.kjetland.jackson.jsonSchema.testData;
 
 import javax.validation.constraints.NotNull;
 
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaProperty;
+
 public class ManyPrimitives {
     public String _string;
+    @JsonSchemaProperty(required = false)
+    public String _notRequiredString;
     public Integer _integer;
     public int _int;
     public Boolean _booleanObject;
@@ -18,8 +22,9 @@ public class ManyPrimitives {
     public ManyPrimitives() {
     }
 
-    public ManyPrimitives(String _string, Integer _integer, int _int, Boolean _booleanObject, boolean _booleanPrimitive, Boolean _booleanObjectWithNotNull, Double _doubleObject, double _doublePrimitive, MyEnum myEnum) {
+    public ManyPrimitives(String _string, String _notRequiredString, Integer _integer, int _int, Boolean _booleanObject, boolean _booleanPrimitive, Boolean _booleanObjectWithNotNull, Double _doubleObject, double _doublePrimitive, MyEnum myEnum) {
         this._string = _string;
+        this._notRequiredString = _notRequiredString;
         this._integer = _integer;
         this._int = _int;
         this._booleanObject = _booleanObject;
@@ -41,6 +46,7 @@ public class ManyPrimitives {
         if (_booleanPrimitive != that._booleanPrimitive) return false;
         if (Double.compare(that._doublePrimitive, _doublePrimitive) != 0) return false;
         if (_string != null ? !_string.equals(that._string) : that._string != null) return false;
+        if (_notRequiredString != null ? !_notRequiredString.equals(that._notRequiredString) : that._notRequiredString != null) return false;
         if (_integer != null ? !_integer.equals(that._integer) : that._integer != null) return false;
         if (_booleanObject != null ? !_booleanObject.equals(that._booleanObject) : that._booleanObject != null) return false;
         if (_booleanObjectWithNotNull != null ? !_booleanObjectWithNotNull.equals(that._booleanObjectWithNotNull) : that._booleanObjectWithNotNull != null) return false;
@@ -54,6 +60,7 @@ public class ManyPrimitives {
         int result;
         long temp;
         result = _string != null ? _string.hashCode() : 0;
+        result = 31 * result + (_notRequiredString != null ? _notRequiredString.hashCode() : 0);
         result = 31 * result + (_integer != null ? _integer.hashCode() : 0);
         result = 31 * result + _int;
         result = 31 * result + (_booleanObject != null ? _booleanObject.hashCode() : 0);

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingFormat.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingFormat.java
@@ -1,11 +1,12 @@
 package com.kjetland.jackson.jsonSchema.testData;
 
+import java.time.OffsetDateTime;
+
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaFormat;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaProperty;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
-
-import java.time.OffsetDateTime;
 
 @JsonSchemaFormat("grid")
 @JsonSchemaDescription("This is our pojo")
@@ -20,6 +21,9 @@ public class PojoUsingFormat {
     @JsonSchemaFormat("checkbox")
     public Boolean choice;
 
+    @JsonSchemaProperty(required = false)
+    public String aNonRequiredString;
+
     @JsonPropertyDescription("This is description from @JsonPropertyDescription")
     public OffsetDateTime dateTime;
 
@@ -29,9 +33,10 @@ public class PojoUsingFormat {
     private PojoUsingFormat() {
     }
 
-    public PojoUsingFormat(String emailValue, Boolean choice, OffsetDateTime dateTime, OffsetDateTime dateTimeWithAnnotation) {
+    public PojoUsingFormat(String emailValue, Boolean choice, String aNonRequiredString, OffsetDateTime dateTime, OffsetDateTime dateTimeWithAnnotation) {
         this.emailValue = emailValue;
         this.choice = choice;
+        this.aNonRequiredString = aNonRequiredString;
         this.dateTime = dateTime;
         this.dateTimeWithAnnotation = dateTimeWithAnnotation;
     }
@@ -45,6 +50,7 @@ public class PojoUsingFormat {
 
         if (emailValue != null ? !emailValue.equals(that.emailValue) : that.emailValue != null) return false;
         if (choice != null ? !choice.equals(that.choice) : that.choice != null) return false;
+        if (aNonRequiredString != null ? !aNonRequiredString.equals(that.aNonRequiredString) : that.aNonRequiredString != null) return false;
         if (dateTime != null ? !dateTime.equals(that.dateTime) : that.dateTime != null) return false;
         return dateTimeWithAnnotation != null ? dateTimeWithAnnotation.equals(that.dateTimeWithAnnotation) : that.dateTimeWithAnnotation == null;
 
@@ -54,6 +60,7 @@ public class PojoUsingFormat {
     public int hashCode() {
         int result = emailValue != null ? emailValue.hashCode() : 0;
         result = 31 * result + (choice != null ? choice.hashCode() : 0);
+        result = 31 * result + (aNonRequiredString != null ? aNonRequiredString.hashCode() : 0);
         result = 31 * result + (dateTime != null ? dateTime.hashCode() : 0);
         result = 31 * result + (dateTimeWithAnnotation != null ? dateTimeWithAnnotation.hashCode() : 0);
         return result;
@@ -64,6 +71,7 @@ public class PojoUsingFormat {
         return "PojoUsingFormat{" +
                 "emailValue='" + emailValue + '\'' +
                 ", choice=" + choice +
+                ", aNonRequiredString=" + aNonRequiredString +
                 ", dateTime=" + dateTime +
                 ", dateTimeWithAnnotation=" + dateTimeWithAnnotation +
                 '}';

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingOptionalJava.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingOptionalJava.java
@@ -1,23 +1,27 @@
 package com.kjetland.jackson.jsonSchema.testData;
 
-import com.kjetland.jackson.jsonSchema.testData.polymorphism1.Child1;
-
 import java.util.List;
 import java.util.Optional;
+
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaProperty;
+import com.kjetland.jackson.jsonSchema.testData.polymorphism1.Child1;
 
 public class PojoUsingOptionalJava {
 
     public Optional<String> _string;
     public Optional<Integer> _integer;
+    @JsonSchemaProperty(required = true)
+    public Optional<Integer> _requiredInteger;
     public Optional<Child1> child1;
     public Optional<List<ClassNotExtendingAnything>> optionalList;
 
     public PojoUsingOptionalJava() {
     }
 
-    public PojoUsingOptionalJava(Optional<String> _string, Optional<Integer> _integer, Optional<Child1> child1, Optional<List<ClassNotExtendingAnything>> optionalList) {
+    public PojoUsingOptionalJava(Optional<String> _string, Optional<Integer> _integer, Optional<Integer> _requiredInteger, Optional<Child1> child1, Optional<List<ClassNotExtendingAnything>> optionalList) {
         this._string = _string;
         this._integer = _integer;
+        this._requiredInteger = _requiredInteger;
         this.child1 = child1;
         this.optionalList = optionalList;
     }
@@ -31,6 +35,7 @@ public class PojoUsingOptionalJava {
 
         if (_string != null ? !_string.equals(that._string) : that._string != null) return false;
         if (_integer != null ? !_integer.equals(that._integer) : that._integer != null) return false;
+        if (_requiredInteger != null ? !_requiredInteger.equals(that._requiredInteger) : that._requiredInteger != null) return false;
         if (child1 != null ? !child1.equals(that.child1) : that.child1 != null) return false;
         return optionalList != null ? optionalList.equals(that.optionalList) : that.optionalList == null;
 
@@ -40,6 +45,7 @@ public class PojoUsingOptionalJava {
     public int hashCode() {
         int result = _string != null ? _string.hashCode() : 0;
         result = 31 * result + (_integer != null ? _integer.hashCode() : 0);
+        result = 31 * result + (_requiredInteger != null ? _requiredInteger.hashCode() : 0);
         result = 31 * result + (child1 != null ? child1.hashCode() : 0);
         result = 31 * result + (optionalList != null ? optionalList.hashCode() : 0);
         return result;
@@ -50,6 +56,7 @@ public class PojoUsingOptionalJava {
         return "PojoUsingOptionalJava{" +
                 "_string=" + _string +
                 ", _integer=" + _integer +
+                ", _requiredInteger=" + _requiredInteger +
                 ", child1=" + child1 +
                 ", optionalList=" + optionalList +
                 '}';

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithArraysNullable.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithArraysNullable.java
@@ -1,27 +1,37 @@
 package com.kjetland.jackson.jsonSchema.testData;
 
-import com.kjetland.jackson.jsonSchema.testData.polymorphism1.Parent;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaProperty;
+import com.kjetland.jackson.jsonSchema.testData.polymorphism1.Parent;
+
 public class PojoWithArraysNullable {
 
     // It was difficult to construct this from scala :)
+    @JsonSchemaProperty(required = false)
     public static List<List<String>> _listOfListOfStringsValues = Arrays.asList(Arrays.asList("1","2"), Arrays.asList("3"));
 
+    @JsonSchemaProperty(required = false)
     public int[] intArray1;
+    @JsonSchemaProperty(required = false)
     public String[] stringArray;
 
+    @JsonSchemaProperty(required = false)
     public List<String> stringList;
 
+    @JsonSchemaProperty(required = false)
     public List<Parent> polymorphismList;
+    @JsonSchemaProperty(required = false)
     public Parent[] polymorphismArray;
+    @JsonSchemaProperty(required = false)
     public List<ClassNotExtendingAnything> regularObjectList;
 
+    @JsonSchemaProperty(required = false)
     public List<List<String>> listOfListOfStrings;
 
+    @JsonSchemaProperty(required = false)
     public Set<MyEnum> setOfUniqueValues;
 
     public PojoWithArraysNullable() {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.34"
+version in ThisBuild := "1.0.35-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.34-SNAPSHOT"
+version in ThisBuild := "1.0.34"


### PR DESCRIPTION
This changes the behavior of how properties are marked as required.

A property is marked as "required":
- **Old:** If a property is primitive, is annotated with `@JsonProperty(required = true)`, or annotated with various `javax.validation` annotations, like `@NotNull`.
- **New:** If a property is **not** an `Optional` type, is annotated with `@JsonProperty(required = true)`, or annotated with various `javax.validation` annotations, like `@NotNull`. Additionally, behavior can be completely overridden with a new annotation `@JsonSchemaProperty(required = true/false)`, allowing consumers to change output if needed.
