### PR TITLE
Mark External Properties (specifically Enums)

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.35-SNAPSHOT"
+version in ThisBuild := "1.0.35"


### PR DESCRIPTION
This introduces the `SchemaExtension` trait, which users of the generator can implement to arbitrarily manipulate the generated schema of models and properties. I only provided support for marking String-type properties at this time, we can implement support for other types if needed in the future. 