### PR TITLE
Update Schema Extension to give extensions more information

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,14 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   useGpg := true,
-  publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
-  // publishTo := {
-  //   val nexus = "https://oss.sonatype.org/"
-  //   if (isSnapshot.value)
-  //     Some("snapshots" at nexus + "content/repositories/snapshots")
-  //   else
-  //     Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  // },
+  //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
+  publishTo := {
+    val nexus = "https://oss.sonatype.org/"
+    if (isSnapshot.value)
+      Some("snapshots" at nexus + "content/repositories/snapshots")
+    else
+      Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  },
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials_sonatype"),
   homepage := Some(url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema")),
   licenses := Seq("MIT" -> url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,14 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   useGpg := true,
-  //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  },
+  publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
+  // publishTo := {
+  //   val nexus = "https://oss.sonatype.org/"
+  //   if (isSnapshot.value)
+  //     Some("snapshots" at nexus + "content/repositories/snapshots")
+  //   else
+  //     Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  // },
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials_sonatype"),
   homepage := Some(url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema")),
   licenses := Seq("MIT" -> url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -699,6 +699,10 @@ class JsonSchemaGenerator
           }
       }
 
+      // Set format for java Longs to int64
+      if (_type.getRawClass.getName.equals(classOf[java.lang.Long].getName)) {
+        setFormat(node, "int64")
+      }
 
       new JsonIntegerFormatVisitor with EnumSupport {
         val _node = node

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -229,8 +229,9 @@ trait SchemaExtension {
     * This is currently only called on String properties!
     * @param node - the schema of the property
     * @param clazz - the class of the property
+    * @param beanProperty - the bean property
     */
-  def modifyProperty(node:ObjectNode, clazz:Class[_]):Unit
+  def modifyProperty(node:ObjectNode, clazz:Class[_], beanProperty:Optional[BeanProperty]):Unit
 
   /**
     * Given a model's schema node and the class of the model, modify the schema node.
@@ -241,7 +242,7 @@ trait SchemaExtension {
 }
 
 class DefaultSchemaExtension extends SchemaExtension {
-  override def modifyProperty(node: ObjectNode, clazz: Class[_]): Unit = {}
+  override def modifyProperty(node: ObjectNode, clazz: Class[_], beanProperty: Optional[BeanProperty]): Unit = {}
   override def modifyModel(node: ObjectNode, clazz: Class[_]): Unit = {}
 }
 
@@ -551,7 +552,7 @@ class JsonSchemaGenerator
       }
 
       if (_type != null) {
-        config.schemaExtension.modifyProperty(node, _type.getRawClass)
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
       }
 
       new JsonStringFormatVisitor with EnumSupport {
@@ -595,6 +596,9 @@ class JsonSchemaGenerator
           }
       }
 
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
+      }
 
       val itemsNode = JsonNodeFactory.instance.objectNode()
       node.set("items", itemsNode)
@@ -654,6 +658,10 @@ class JsonSchemaGenerator
           }
       }
 
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
+      }
+
       new JsonNumberFormatVisitor  with EnumSupport {
         val _node = node
         override def numberType(_type: NumberType): Unit = l(s"JsonNumberFormatVisitor.numberType: ${_type}")
@@ -704,6 +712,10 @@ class JsonSchemaGenerator
         setFormat(node, "int64")
       }
 
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
+      }
+
       new JsonIntegerFormatVisitor with EnumSupport {
         val _node = node
         override def numberType(_type: NumberType): Unit = l(s"JsonIntegerFormatVisitor.numberType: ${_type}")
@@ -732,6 +744,10 @@ class JsonSchemaGenerator
             defaultValue =>
               node.put("default", defaultValue.value().toBoolean)
           }
+      }
+
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
       }
 
       new JsonBooleanFormatVisitor with EnumSupport {
@@ -769,6 +785,9 @@ class JsonSchemaGenerator
       objectMapper.acceptJsonFormatVisitor(tryToReMapType(_type.getContentType), childVisitor)
       definitionsHandler.popworkInProgress()
 
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
+      }
 
       new JsonMapFormatVisitor with MySerializerProvider {
         override def keyFormat(handler: JsonFormatVisitable, keyType: JavaType): Unit = {
@@ -1038,6 +1057,10 @@ class JsonSchemaGenerator
                   thisObjectNode.set("options", objectOptionsNode)
                 }
 
+            }
+
+            if (_type != null) {
+              config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
             }
 
             Some(new JsonObjectFormatVisitor with MySerializerProvider {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.38"
+version in ThisBuild := "1.0.39-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.38-SNAPSHOT"
+version in ThisBuild := "1.0.38"


### PR DESCRIPTION
This expands the scope of the schema extension to work on all property types and models, as well as passing in more information on the property itself when available, i.e. the BeanProperty object.
