### PR TITLE
Modify property after object format properties

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -1225,6 +1225,9 @@ class JsonSchemaGenerator
                   a =>
                     injectFromJsonSchemaInject(a, thisPropertyNode.meta)
                 }
+
+                // This is only passing in the meta portion of the property node to be modified!
+                config.schemaExtension.modifyProperty(thisPropertyNode.meta, _type.getRawClass, Optional.ofNullable(prop.orNull))
               }
 
               override def optionalProperty(prop: BeanProperty): Unit = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.39"
+version in ThisBuild := "1.0.40-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.39-SNAPSHOT"
+version in ThisBuild := "1.0.39"


### PR DESCRIPTION
This adds a call to `config.schemaExtension.modifyProperty` to `expectObjectFormat.myPropertyHandler`, as we weren't currently allowing modification to object properties.