### PR TITLE
Support to JsonSerializer annot

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,0 +1,26 @@
+buildpack:
+  host: git.hubteam.com
+  organization: HubSpotProtected
+  repository: Blazar-Buildpack-Java
+  branch: v2-prebuilt
+
+stepActivation:
+  uploadAndNotify:
+    branches: ['hubspot-release']
+
+steps:
+  - description: "Test across all supported Scala Versions"
+    commands:
+      - echo "SBT_OPTS='-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M' +test"
+      - SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" +test
+
+  - description: "Package Jar"
+    commands:
+      - echo "sbt package"
+      - sbt package
+
+  - name: uploadAndNotify
+      description: "Notifying deploy service"
+      activeByDefault: false
+      commands:
+        - command: publish-build-success --project

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -6,7 +6,7 @@ buildpack:
 
 stepActivation:
   uploadAndNotify:
-    branches: ['hubspot-release']
+    branches: ['hubspot']
 
 steps:
   - description: "Test across all supported Scala Versions"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -10,8 +10,7 @@ buildpack:
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
   PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.0'
-  SCALA_VERSION: "1.2.3"  # this should match what's in project/build.properties
-  SBT_TAR_FILE_NAME: "sbt-$SCALA_VERSION.tgz"
+  SBT_TAR_FILE_NAME: "sbt-1.3.8.tgz"
   SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
   SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"
   HOME_BIN: "$HOME/bin"
@@ -42,7 +41,7 @@ before:
 
   - description: "Move artifacts to upload directory"
     commands:
-      - export PROJECT_VERSION=$($SBT_BIN/sbt -warn 'print version')
+      - echo export PROJECT_VERSION=$($SBT_BIN/sbt -warn 'print version') >> $BUILD_COMMAND_RC_FILE
       - mkdir $PUBLISH_DIR
       - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -10,8 +10,9 @@ buildpack:
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
   PUBLISH_DIR_WITHOUT_VERSION: '"$PROJECT_NAME"_2.12'
-  SBT_TAR_FILE_NAME: "sbt-1.3.8.tgz"
-  SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
+  SBT_TAR_VERSION: "1.3.8"
+  SBT_TAR_FILE_NAME: "sbt-$SBT_TAR_VERSION.tgz"
+  SBT_TAR_LINK: "https://github.com/sbt/sbt/releases/download/v$SBT_TAR_VERSION/$SBT_TAR_FILE_NAME"
   SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"
   HOME_BIN: "$HOME/bin"
   SBT_BIN: "$HOME_BIN/sbt/bin"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,4 +1,5 @@
-MAVEN_OPTS: -Xmx1024m -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+buildResources:
+  memoryMb: 4096
 
 buildpack:
   host: git.hubteam.com
@@ -7,6 +8,9 @@ buildpack:
   branch: v2-prebuilt
 
 env:
+  PROJECT_NAME: "mbknor-jackson-jsonschema"
+  PROJECT_VERSION: "1.0-hubspot-SNAPSHOT" # this should match what's in version.sbt
+  PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.0'
   SCALA_VERSION: "1.2.3"  # this should match what's in project/build.properties
   SBT_TAR_FILE_NAME: "sbt-$SCALA_VERSION.tgz"
   SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
@@ -18,7 +22,7 @@ stepActivation:
   uploadAndNotify:
     branches: ['hubspot']
 
-steps:
+before:
   - description: "Download and install sbt"
     commands:
       - mkdir -p /tmp/sbt-install
@@ -31,11 +35,26 @@ steps:
 
   - description: "Test across all supported Scala Versions"
     commands:
-      - $SBT_BIN/sbt +test
+      - $SBT_BIN/sbt test #todo: change to +test
 
-  - description: "Package Jar"
+  - description: "Package + Publish Local"
     commands:
-      - $SBT_BIN/sbt package
+      - $SBT_BIN/sbt publish
+
+  - description: "Move artifacts to upload directory"
+    commands:
+      - ls -al target/com/kjetland/mbknor-jackson-jsonschema_2.12/"$PROJECT_VERSION"
+      - ls -al target/scala-2.12
+      - mkdir $PUBLISH_DIR
+      - ls -al
+      - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
+      - ls -al
+      - ls -al $PUBLISH_DIR #testing: confirm files copied
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml #todo: change the branch
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".jar $PUBLISH_DIR/main.jar
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-sources.jar $PUBLISH_DIR/sources.jar
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-javadoc.jar $PUBLISH_DIR/javadoc.jar
+      - ls -al $PUBLISH_DIR #testing: confirm success
 
   - name: uploadAndNotify
     description: "Notifying deploy service"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -35,7 +35,7 @@ before:
 
   - description: "Test across all supported Scala Versions"
     commands:
-      - $SBT_BIN/sbt test #todo: change to +test
+      - $SBT_BIN/sbt +test
 
   - description: "Package + Publish Local"
     commands:
@@ -43,18 +43,12 @@ before:
 
   - description: "Move artifacts to upload directory"
     commands:
-      - ls -al target/com/kjetland/mbknor-jackson-jsonschema_2.12/"$PROJECT_VERSION"
-      - ls -al target/scala-2.12
       - mkdir $PUBLISH_DIR
-      - ls -al
       - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
-      - ls -al
-      - ls -al $PUBLISH_DIR #testing: confirm files copied
-      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml #todo: change the branch
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".jar $PUBLISH_DIR/main.jar
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-sources.jar $PUBLISH_DIR/sources.jar
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-javadoc.jar $PUBLISH_DIR/javadoc.jar
-      - ls -al $PUBLISH_DIR #testing: confirm success
 
   - name: uploadAndNotify
     description: "Notifying deploy service"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -9,7 +9,6 @@ buildpack:
 
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
-  PROJECT_VERSION: "1.0-hubspot-SNAPSHOT" # this should match what's in version.sbt
   PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.0'
   SCALA_VERSION: "1.2.3"  # this should match what's in project/build.properties
   SBT_TAR_FILE_NAME: "sbt-$SCALA_VERSION.tgz"
@@ -43,6 +42,7 @@ before:
 
   - description: "Move artifacts to upload directory"
     commands:
+      - export PROJECT_VERSION=$($SBT_BIN/sbt -warn 'print version')
       - mkdir $PUBLISH_DIR
       - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -4,23 +4,39 @@ buildpack:
   repository: Blazar-Buildpack-Java
   branch: v2-prebuilt
 
+env:
+  SCALA_VERSION: "1.2.3"  # this should match what's in project/build.properties
+  SBT_TAR_FILE_NAME: "sbt-$SCALA_VERSION.tgz"
+  SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
+  SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"
+  HOME_BIN: "$HOME/bin"
+  SBT_BIN: "$HOME_BIN/sbt/bin"
+
 stepActivation:
   uploadAndNotify:
     branches: ['hubspot']
 
 steps:
+  - description: "Download and install sbt"
+    commands:
+      - mkdir -p /tmp/sbt-install
+      - mkdir -p $HOME_BIN
+      - wget --quiet $SBT_TAR_LINK -O $SBT_FILE
+      - tar -xvzf $SBT_FILE -C $HOME_BIN
+      - printf '#!/bin/bash \nSBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled" \njava $SBT_OPTS -jar `dirname $0`/sbt-launch.jar "$@"' > $SBT_BIN/sbt
+      - chmod u+x $SBT_BIN/sbt
+      - rm -rf /tmp/sbt-install
+
   - description: "Test across all supported Scala Versions"
     commands:
-      - echo "SBT_OPTS='-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M' +test"
-      - SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" +test
+      - SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" $SBT_BIN/sbt +test
 
   - description: "Package Jar"
     commands:
-      - echo "sbt package"
-      - sbt package
+      - $SBT_BIN/sbt package
 
   - name: uploadAndNotify
-      description: "Notifying deploy service"
-      activeByDefault: false
-      commands:
-        - command: publish-build-success --project
+    description: "Notifying deploy service"
+    activeByDefault: false
+    commands:
+      - command: publish-build-success --project

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -9,7 +9,7 @@ buildpack:
 
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
-  PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.0'
+  PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.1'
   SBT_TAR_FILE_NAME: "sbt-1.3.8.tgz"
   SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
   SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,3 +1,5 @@
+MAVEN_OPTS: -Xmx1024m -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+
 buildpack:
   host: git.hubteam.com
   organization: HubSpotProtected
@@ -23,13 +25,13 @@ steps:
       - mkdir -p $HOME_BIN
       - wget --quiet $SBT_TAR_LINK -O $SBT_FILE
       - tar -xvzf $SBT_FILE -C $HOME_BIN
-      - printf '#!/bin/bash \nSBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled" \njava $SBT_OPTS -jar `dirname $0`/sbt-launch.jar "$@"' > $SBT_BIN/sbt
+      - printf '#!/bin/bash \nSBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M -XX:+CMSClassUnloadingEnabled" \njava $SBT_OPTS -jar `dirname $0`/sbt-launch.jar "$@"' > $SBT_BIN/sbt
       - chmod u+x $SBT_BIN/sbt
       - rm -rf /tmp/sbt-install
 
   - description: "Test across all supported Scala Versions"
     commands:
-      - SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" $SBT_BIN/sbt +test
+      - $SBT_BIN/sbt +test
 
   - description: "Package Jar"
     commands:

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -9,7 +9,7 @@ buildpack:
 
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
-  PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.1'
+  PUBLISH_DIR_WITHOUT_VERSION: '"$PROJECT_NAME"_2.12'
   SBT_TAR_FILE_NAME: "sbt-1.3.8.tgz"
   SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
   SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"
@@ -42,6 +42,7 @@ before:
   - description: "Move artifacts to upload directory"
     commands:
       - echo export PROJECT_VERSION=$($SBT_BIN/sbt -warn 'print version') >> $BUILD_COMMAND_RC_FILE
+      - echo export PUBLISH_DIR=$PUBLISH_DIR_WITHOUT_VERSION-$(echo $PROJECT_VERSION | sed -n 's/^\([[:digit:]]*\.[[:digit:]]*\)-.*$/\1/p') >> $BUILD_COMMAND_RC_FILE
       - mkdir $PUBLISH_DIR
       - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml

--- a/.hubspot-blazar-discovery.yaml
+++ b/.hubspot-blazar-discovery.yaml
@@ -1,0 +1,1 @@
+disabledDiscoveries: ["maven"]

--- a/.hubspot-blazar-discovery.yaml
+++ b/.hubspot-blazar-discovery.yaml
@@ -1,1 +1,0 @@
-disabledDiscoveries: ["maven"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: scala
-scala:
-   - 2.10.4
-   - 2.11.8
-   - 2.12.0
-
-dist: trusty
-jdk:
-- oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 Jackson jsonSchema Generator (Fork)
 ===================================
-[![Build Status](https://travis-ci.org/zrrobbins/mbknor-jackson-jsonSchema.svg?branch=master)](https://travis-ci.org/zrrobbins/mbknor-jackson-jsonSchema)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.zrrobbins/mbknor-jackson-jsonschema_2.12/badge.svg)](https://search.maven.org/search?q=mbknor-jackson-jsonschema%20com.github.zrrobbins)
 
 Forked from https://github.com/mbknor/mbknor-jackson-jsonSchema, head there for more info. This is a slightly modified version to fit some niche use cases.

--- a/build.sbt
+++ b/build.sbt
@@ -39,12 +39,14 @@ lazy val commonSettings = Seq(
 val jacksonVersion = "2.9.8"
 val jacksonModuleScalaVersion = "2.9.8"
 val slf4jVersion = "1.7.26"
+val swaggerApiVersion = "1.5.13"
 
 
 lazy val deps  = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "javax.validation" % "validation-api" % "2.0.1.Final",
   "org.slf4j" % "slf4j-api" % slf4jVersion,
+  "io.swagger" % "swagger-annotations" % swaggerApiVersion,
   "io.github.classgraph" % "classgraph" % "4.8.22",
   "com.google.guava" % "guava" % "25.0-jre", 
   "org.scalatest" %% "scalatest" % "3.0.7" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,18 @@
 lazy val commonSettings = Seq(
-  organization := "com.hubspot",
+  organization := "com.kjetland",
+  organizationName := "mbknor",
   scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0-M5"),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
-  homepage := Some(url("https://github.com/hubspot/mbknor-jackson-jsonSchema")),
-  licenses := Seq("MIT" -> url("https://github.com/hubspot/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
+  homepage := Some(url("https://github.com/mbknor/mbknor-jackson-jsonSchema")),
+  licenses := Seq("MIT" -> url("https://github.com/mbknor/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
   startYear := Some(2016),
   scmInfo := Some(
     ScmInfo(
-      url("https://github.com/hubspot/mbknor-jackson-jsonSchema"),
-      "scm:git@github.com:hubspot/mbknor-jackson-jsonSchema.git"
+      url("https://github.com/mbknor/mbknor-jackson-jsonSchema"),
+      "scm:git@github.com:mbknor/mbknor-jackson-jsonSchema.git"
     )
   ),
   developers := List(

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val commonSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
+  publishTo := Some(Resolver.file("file",  new File("target"))),
   homepage := Some(url("https://github.com/mbknor/mbknor-jackson-jsonSchema")),
   licenses := Seq("MIT" -> url("https://github.com/mbknor/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
   startYear := Some(2016),

--- a/build.sbt
+++ b/build.sbt
@@ -1,30 +1,17 @@
-import ReleaseTransformations._
-import sbtrelease.ReleasePlugin.autoImport.releaseStepCommand
-
 lazy val commonSettings = Seq(
-  organization := "com.github.zrrobbins",
+  organization := "com.hubspot",
   scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0-M5"),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
-  useGpg := true,
-  //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  },
-  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials_sonatype"),
-  homepage := Some(url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema")),
-  licenses := Seq("MIT" -> url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
+  homepage := Some(url("https://github.com/hubspot/mbknor-jackson-jsonSchema")),
+  licenses := Seq("MIT" -> url("https://github.com/hubspot/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
   startYear := Some(2016),
   scmInfo := Some(
     ScmInfo(
-      url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema"),
-      "scm:git@github.com:zrrobbins/mbknor-jackson-jsonSchema.git"
+      url("https://github.com/hubspot/mbknor-jackson-jsonSchema"),
+      "scm:git@github.com:hubspot/mbknor-jackson-jsonSchema.git"
     )
   ),
   developers := List(
@@ -38,8 +25,6 @@ lazy val commonSettings = Seq(
   compileOrder in Test := CompileOrder.Mixed,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq("-unchecked", "-deprecation"),
-  releaseCrossBuild := true,
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   scalacOptions in(Compile, doc) ++= Seq(scalaVersion.value).flatMap {
     case v if v.startsWith("2.12") =>
       Seq("-no-java-comments") //workaround for scala/scala-dev#249
@@ -74,18 +59,3 @@ lazy val root = (project in file("."))
   .settings(name := "mbknor-jackson-jsonSchema")
   .settings(commonSettings: _*)
   .settings(libraryDependencies ++= (deps))
-
-
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  publishArtifacts,
-  setNextVersion,
-  commitNextVersion,
-  pushChanges,
-  releaseStepCommand("sonatypeRelease")
-)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,0 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.node.{ArrayNode, JsonNodeFactory, ObjectNo
 import com.fasterxml.jackson.databind.util.ClassUtil
 import com.kjetland.jackson.jsonSchema.annotations._
 import io.github.classgraph.{ClassGraph, ScanResult}
+import io.swagger.annotations.ApiModelProperty
 import javax.validation.constraints._
 import org.slf4j.LoggerFactory
 
@@ -1105,7 +1106,14 @@ class JsonSchemaGenerator
 
                 val thisPropertyNode:PropertyNode = {
                   val thisPropertyNode = JsonNodeFactory.instance.objectNode()
-                  propertiesNode.set(propertyName, thisPropertyNode)
+                  val apiModelProperty:Option[ApiModelProperty] = prop.flatMap(p => Option(p.getAnnotation(classOf[ApiModelProperty])))
+
+                  if (apiModelProperty.isDefined && apiModelProperty.exists(!_.name().equals(""))) {
+                    propertiesNode.set(apiModelProperty.get.name(), thisPropertyNode)
+                  } else {
+                    propertiesNode.set(propertyName, thisPropertyNode)
+                  }
+
 
                   if ( config.usePropertyOrdering ) {
                     thisPropertyNode.put("propertyOrder", nextPropertyOrderIndex)

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -1098,8 +1098,8 @@ class JsonSchemaGenerator
                   classOf[com.google.common.base.Optional[_]].isAssignableFrom(propertyType.getRawClass)
 
                 // Check if we should set this property as required. Anything with a @JsonProperty that
-                // has "required" set to true, various javax.validation annotations, or any property
-                // that is NOT an Optional type is set as required by default. The @JsonSchemaProperty
+                // has "required" set to true, various javax.validation annotations, has a JsonInclude annotation other than Include.ALWAYS
+                // or any property that is NOT an Optional type is set as required by default. The @JsonSchemaProperty
                 // annotation can be used to override any of these conditions.
                 val requiredProperty:Boolean = jsonSchemaRequired.getOrElse(jsonPropertyRequired || validationAnnotationRequired(prop) || (!optionalType && !jsonIncludeOptional))
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -677,6 +677,9 @@ class JsonSchemaGenerator
         log.warn(s"Not able to generate jsonSchema-info for type: ${_type} - probably using custom serializer which does not override acceptJsonFormatVisitor")
       }
 
+      if(_type != null && _type.isTypeOrSubTypeOf(classOf[JsonNode])) {
+        node.put("type", "object")
+      }
 
       new JsonAnyFormatVisitor {
       }

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -1183,9 +1183,7 @@ class JsonSchemaGenerator
                   p =>
                     Option(p.getAnnotation(classOf[JsonSerialize])).map {
                       jsonSerialize =>
-                          if(jsonSerialize.using().equals(classOf[ToStringSerializer])) {
-                            ToStringSerializer.instance.acceptJsonFormatVisitor(childVisitor, propertyType)
-                          }
+                        jsonSerialize.using().newInstance.acceptJsonFormatVisitor(childVisitor, propertyType)
                     }
                 }
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -4,7 +4,7 @@ import java.util
 import java.util.function.Supplier
 import java.util.{Optional, List => JList}
 
-import com.fasterxml.jackson.annotation.{JsonPropertyDescription, JsonSubTypes, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{JsonInclude, JsonPropertyDescription, JsonSubTypes, JsonTypeInfo}
 import com.fasterxml.jackson.core.JsonParser.NumberType
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
@@ -1088,6 +1088,10 @@ class JsonSchemaGenerator
                   .flatMap(p => Option(p.getAnnotation(classOf[JsonSchemaProperty])))
                   .map(_.required())
 
+                val jsonIncludeOptional:Boolean = prop
+                  .flatMap(p => Option(p.getAnnotation(classOf[JsonInclude])))
+                  .map(!_.value().equals(JsonInclude.Include.ALWAYS)).getOrElse(false)
+
                 // Figure out if the type is considered optional by either Java or Scala.
                 val optionalType:Boolean = classOf[Option[_]].isAssignableFrom(propertyType.getRawClass) ||
                   classOf[Optional[_]].isAssignableFrom(propertyType.getRawClass) ||
@@ -1097,7 +1101,7 @@ class JsonSchemaGenerator
                 // has "required" set to true, various javax.validation annotations, or any property
                 // that is NOT an Optional type is set as required by default. The @JsonSchemaProperty
                 // annotation can be used to override any of these conditions.
-                val requiredProperty:Boolean = jsonSchemaRequired.getOrElse(jsonPropertyRequired || validationAnnotationRequired(prop) || !optionalType)
+                val requiredProperty:Boolean = jsonSchemaRequired.getOrElse(jsonPropertyRequired || validationAnnotationRequired(prop) || (!optionalType && !jsonIncludeOptional))
 
                 val thisPropertyNode:PropertyNode = {
                   val thisPropertyNode = JsonNodeFactory.instance.objectNode()

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -677,7 +677,7 @@ class JsonSchemaGenerator
         log.warn(s"Not able to generate jsonSchema-info for type: ${_type} - probably using custom serializer which does not override acceptJsonFormatVisitor")
       }
 
-      if(_type != null && _type.isTypeOrSubTypeOf(classOf[JsonNode])) {
+      if(_type != null && (_type.isTypeOrSubTypeOf(classOf[JsonNode]) || _type.getRawClass == classOf[Object])) {
         node.put("type", "object")
       }
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -1463,6 +1463,24 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers with BeforeAndAfter
     }
 
   }
+
+  test("pojo with ToStringSerializer") {
+
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.pojoWithJsonSerializer)
+      val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.pojoWithJsonSerializer.getClass, Some(jsonNode))
+
+      assert(schema.at("/properties/realLong/type").asText() == "integer")
+
+      assert(schema.at("/properties/realDouble/type").asText() == "number")
+
+      assert(schema.at("/properties/realString/type").asText() == "string")
+
+      assert(schema.at("/properties/longSerializedAsString/type").asText() == "string")
+
+      assert(schema.at("/properties/doubleSerializedAsString/type").asText() == "string")
+    }
+  }
 }
 
 trait TestData {
@@ -1644,5 +1662,7 @@ trait TestData {
   val genericClassVoid = new GenericClassVoid()
 
   val genericMapLike = new GenericMapLike(Collections.singletonMap("foo", "bar"))
+
+  val pojoWithJsonSerializer = new PojoWithJsonSerializer()
 
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -1479,6 +1479,11 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers with BeforeAndAfter
       assert(schema.at("/properties/longSerializedAsString/type").asText() == "string")
 
       assert(schema.at("/properties/doubleSerializedAsString/type").asText() == "string")
+
+      assert(schema.at("/properties/localDate/type").asText() == "string")
+
+      assert(schema.at("/properties/localDate/format").asText() == "date")
+
     }
   }
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
@@ -1,5 +1,13 @@
 package com.kjetland.jackson.jsonSchema.testData;
 
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import com.kjetland.jackson.jsonSchema.testData.utils.LocalDateSerializer;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
@@ -15,6 +23,9 @@ public class PojoWithJsonSerializer {
 
     @JsonSerialize(using = ToStringSerializer.class)
     public double doubleSerializedAsString = 5.5;
+
+    @JsonSerialize(using = LocalDateSerializer.class)
+    public LocalDate localDate = LocalDate.of(2000, 1,1 );
 
     @Override
     public boolean equals(Object o) {

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
@@ -1,0 +1,38 @@
+package com.kjetland.jackson.jsonSchema.testData;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+public class PojoWithJsonSerializer {
+    public long realLong = 4;
+
+    public double realDouble = 4.5;
+
+    public String realString = "str";
+
+    @JsonSerialize(using = ToStringSerializer.class)
+    public long longSerializedAsString = 5;
+
+    @JsonSerialize(using = ToStringSerializer.class)
+    public double doubleSerializedAsString = 5.5;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PojoWithJsonSerializer that = (PojoWithJsonSerializer) o;
+
+        if (realLong != that.realLong) return false;
+        if (longSerializedAsString != that.longSerializedAsString) return false;
+        return realString != null ? realString.equals(that.realString) : that.realString == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (realLong ^ (realLong >>> 32));
+        result = 31 * result + (realString != null ? realString.hashCode() : 0);
+        result = 31 * result + (int) (longSerializedAsString ^ (longSerializedAsString >>> 32));
+        return result;
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/utils/LocalDateSerializer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/utils/LocalDateSerializer.java
@@ -1,0 +1,21 @@
+package com.kjetland.jackson.jsonSchema.testData.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateSerializer extends JsonSerializer<LocalDate> {
+
+    @Override
+    public void serialize(
+            LocalDate localDate,
+            JsonGenerator jsonGenerator,
+            SerializerProvider provider
+    ) throws IOException {
+        jsonGenerator.writeString(localDate.format(DateTimeFormatter.ISO_LOCAL_DATE));
+    }
+}
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3-hubspot-SNAPSHOT"
+version in ThisBuild := "1.4-hubspot-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5-hubspot-SNAPSHOT"
+version in ThisBuild := "1.6-hubspot-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4-hubspot-SNAPSHOT"
+version in ThisBuild := "1.5-hubspot-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.35"
+version in ThisBuild := "1.0-hubspot-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1-hubspot-SNAPSHOT"
+version in ThisBuild := "1.2-hubspot-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2-hubspot-SNAPSHOT"
+version in ThisBuild := "1.3-hubspot-SNAPSHOT"


### PR DESCRIPTION
### What
Added support for JsonSerializer annotation in JsonSchemaGenerator, when a property is annotated with @JsonSerialize, we parse the serializer in this annotation and call `acceptJsonFormatVisitor` on it, the default behavior of this method is defined in [JsonSerializer](https://github.com/FasterXML/jackson-databind/blob/8c9c75a48bf302e7cf0c8fcd1dbfe2e1d53b5f2c/src/main/java/com/fasterxml/jackson/databind/JsonSerializer.java#L276) and can be override by custom serializer.

### Test
added `PojoWithJsonSerializer` which have properties annotated with both `ToStringSerializer` and a custom serializer `LocalDateSerializer`, test passed with expected result

### Manual Test
Updated the pom dependency in HSMP to `1.0-support-toStringSerializer-annot-SNAPSHOT`
run `maven clean install` in HSMP
run `maven clean compile swagger:preview` locally in cv-public-api, check the generated spec and thread id is marked as `string` as expected

<img width="643" alt="Screen Shot 2021-09-24 at 1 00 42 PM" src="https://user-images.githubusercontent.com/65409677/134714424-89167c9d-f955-411e-b786-ece9d0fe5757.png">

@zrrobbins 